### PR TITLE
fix: disabling cs or scoreboard overhaul

### DIFF
--- a/src/main/java/me/owdding/customscoreboard/mixins/compat/ScoreboardConfigMixin.java
+++ b/src/main/java/me/owdding/customscoreboard/mixins/compat/ScoreboardConfigMixin.java
@@ -15,7 +15,7 @@ public class ScoreboardConfigMixin {
 
     @ModifyReturnValue(method = "isEnabled", at = @At("RETURN"))
     private static boolean customscoreboard$isEnabled(boolean original) {
-        ModCompat.INSTANCE.setScoreboardOverhaulEnabled(original);
+        ModCompat.INSTANCE.setOverhaulEnabled(original);
         return original;
     }
 

--- a/src/main/java/me/owdding/customscoreboard/mixins/compat/ScoreboardConfigMixin.java
+++ b/src/main/java/me/owdding/customscoreboard/mixins/compat/ScoreboardConfigMixin.java
@@ -2,7 +2,6 @@ package me.owdding.customscoreboard.mixins.compat;
 
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.moulberry.mixinconstraints.annotations.IfModLoaded;
-import me.jfenn.scoreboardoverhaul.common.config.ConfigManager;
 import me.jfenn.scoreboardoverhaul.common.config.ScoreboardConfig;
 import me.owdding.customscoreboard.feature.ModCompat;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,15 +10,12 @@ import org.spongepowered.asm.mixin.injection.At;
 
 @Pseudo
 @IfModLoaded("scoreboard-overhaul")
-@Mixin(value = {ConfigManager.class}, remap = false)
-public class ScoreboardOverhaulConfigManagerMixin {
+@Mixin(value = ScoreboardConfig.class, remap = false)
+public class ScoreboardConfigMixin {
 
-    @ModifyReturnValue(
-        method = "access$getInstance$cp",
-        at = @At("RETURN")
-    )
-    private static ScoreboardConfig customscoreboard$access$getInstance(ScoreboardConfig original) {
-        ModCompat.INSTANCE.setScoreboardOverhaulEnabled(original.isEnabled());
+    @ModifyReturnValue(method = "isEnabled", at = @At("RETURN"))
+    private static boolean customscoreboard$isEnabled(boolean original) {
+        ModCompat.INSTANCE.setScoreboardOverhaulEnabled(original);
         return original;
     }
 

--- a/src/main/java/me/owdding/customscoreboard/mixins/compat/ScoreboardOverhaulConfigManagerMixin.java
+++ b/src/main/java/me/owdding/customscoreboard/mixins/compat/ScoreboardOverhaulConfigManagerMixin.java
@@ -1,0 +1,26 @@
+package me.owdding.customscoreboard.mixins.compat;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
+import me.jfenn.scoreboardoverhaul.common.config.ConfigManager;
+import me.jfenn.scoreboardoverhaul.common.config.ScoreboardConfig;
+import me.owdding.customscoreboard.feature.ModCompat;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Pseudo
+@IfModLoaded("scoreboard-overhaul")
+@Mixin(value = {ConfigManager.class}, remap = false)
+public class ScoreboardOverhaulConfigManagerMixin {
+
+    @ModifyReturnValue(
+        method = "access$getInstance$cp",
+        at = @At("RETURN")
+    )
+    private static ScoreboardConfig customscoreboard$access$getInstance(ScoreboardConfig original) {
+        ModCompat.INSTANCE.setScoreboardOverhaulEnabled(original.isEnabled());
+        return original;
+    }
+
+}

--- a/src/main/java/me/owdding/customscoreboard/mixins/compat/SkyHanniCustomScoreboardMixin.java
+++ b/src/main/java/me/owdding/customscoreboard/mixins/compat/SkyHanniCustomScoreboardMixin.java
@@ -2,7 +2,7 @@ package me.owdding.customscoreboard.mixins.compat;
 
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.moulberry.mixinconstraints.annotations.IfModLoaded;
-import me.owdding.customscoreboard.feature.SkyHanniCompat;
+import me.owdding.customscoreboard.feature.ModCompat;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
@@ -20,7 +20,7 @@ public class SkyHanniCustomScoreboardMixin {
         remap = false
     )
     boolean customscoreboard$isEnabled(boolean original) {
-        SkyHanniCompat.INSTANCE.setSkyhanniCustomScoreboardEnabled(original);
+        ModCompat.INSTANCE.setSkyhanniCustomScoreboardEnabled(original);
         return original;
     }
 

--- a/src/main/kotlin/me/owdding/customscoreboard/feature/ModCompat.kt
+++ b/src/main/kotlin/me/owdding/customscoreboard/feature/ModCompat.kt
@@ -13,9 +13,10 @@ import tech.thatgravyboat.skyblockapi.utils.text.TextStyle.command
 import tech.thatgravyboat.skyblockapi.utils.text.TextStyle.hover
 
 @Module
-object SkyHanniCompat {
+object ModCompat {
 
     var isSkyhanniCustomScoreboardEnabled = false
+    var isScoreboardOverhaulEnabled = false
 
     @Subscription
     fun onProfile(event: ProfileChangeEvent) {

--- a/src/main/kotlin/me/owdding/customscoreboard/feature/ModCompat.kt
+++ b/src/main/kotlin/me/owdding/customscoreboard/feature/ModCompat.kt
@@ -17,11 +17,11 @@ import tech.thatgravyboat.skyblockapi.utils.text.TextStyle.hover
 object ModCompat {
 
     var isSkyhanniCustomScoreboardEnabled = false
-    var isScoreboardOverhaulEnabled = false
+    var isOverhaulEnabled = false
 
     val isScoreboardOverhaulLoaded = FabricLoader.getInstance().isModLoaded("scoreboard-overhaul")
 
-    fun isScoreboardOverhaulEnabled() = isScoreboardOverhaulLoaded && isScoreboardOverhaulEnabled
+    fun isScoreboardOverhaulEnabled() = isScoreboardOverhaulLoaded && isOverhaulEnabled
 
     @Subscription
     fun onProfile(event: ProfileChangeEvent) {

--- a/src/main/kotlin/me/owdding/customscoreboard/feature/ModCompat.kt
+++ b/src/main/kotlin/me/owdding/customscoreboard/feature/ModCompat.kt
@@ -3,6 +3,7 @@ package me.owdding.customscoreboard.feature
 import me.owdding.customscoreboard.config.MainConfig
 import me.owdding.customscoreboard.utils.Utils.sendWithPrefix
 import me.owdding.ktmodules.Module
+import net.fabricmc.loader.api.FabricLoader
 import tech.thatgravyboat.skyblockapi.api.events.base.Subscription
 import tech.thatgravyboat.skyblockapi.api.events.profile.ProfileChangeEvent
 import tech.thatgravyboat.skyblockapi.utils.text.Text
@@ -17,6 +18,10 @@ object ModCompat {
 
     var isSkyhanniCustomScoreboardEnabled = false
     var isScoreboardOverhaulEnabled = false
+
+    val isScoreboardOverhaulLoaded = FabricLoader.getInstance().isModLoaded("scoreboard-overhaul")
+
+    fun isScoreboardOverhaulEnabled() = isScoreboardOverhaulLoaded && isScoreboardOverhaulEnabled
 
     @Subscription
     fun onProfile(event: ProfileChangeEvent) {

--- a/src/main/kotlin/me/owdding/customscoreboard/feature/customscoreboard/CustomScoreboardRenderer.kt
+++ b/src/main/kotlin/me/owdding/customscoreboard/feature/customscoreboard/CustomScoreboardRenderer.kt
@@ -12,7 +12,6 @@ import me.owdding.customscoreboard.utils.rendering.RenderUtils.drawTexture
 import me.owdding.customscoreboard.utils.rendering.alignment.HorizontalAlignment
 import me.owdding.customscoreboard.utils.rendering.alignment.VerticalAlignment
 import me.owdding.ktmodules.Module
-import net.fabricmc.loader.api.FabricLoader
 import net.minecraft.client.gui.layouts.LayoutElement
 import net.minecraft.client.gui.screens.ChatScreen
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
@@ -30,8 +29,6 @@ import tech.thatgravyboat.skyblockapi.helpers.McClient
 
 @Module
 object CustomScoreboardRenderer {
-
-    private val isOverhaulLoaded = FabricLoader.getInstance().isModLoaded("scoreboard-overhaul")
 
     var lines: List<ScoreboardLine> = emptyList()
         private set
@@ -202,6 +199,5 @@ object CustomScoreboardRenderer {
     private fun isEnabled() = (LocationAPI.isOnSkyBlock || MainConfig.outsideSkyBlock) && MainConfig.enabled
     fun shouldUseCustomLines() = MainConfig.customLines && LocationAPI.isOnSkyBlock
     private fun hideHypixelScoreboard() = isEnabled() && MainConfig.hideHypixelScoreboard
-    fun renderScoreboardOverhaul() =
-        LocationAPI.isOnSkyBlock && MainConfig.enabled && isOverhaulLoaded && MainConfig.scoreboardOverhaul && ModCompat.isScoreboardOverhaulEnabled
+    fun renderScoreboardOverhaul() = LocationAPI.isOnSkyBlock && MainConfig.enabled && MainConfig.scoreboardOverhaul && ModCompat.isScoreboardOverhaulEnabled()
 }

--- a/src/main/kotlin/me/owdding/customscoreboard/feature/customscoreboard/CustomScoreboardRenderer.kt
+++ b/src/main/kotlin/me/owdding/customscoreboard/feature/customscoreboard/CustomScoreboardRenderer.kt
@@ -3,6 +3,7 @@ package me.owdding.customscoreboard.feature.customscoreboard
 import me.owdding.customscoreboard.config.MainConfig
 import me.owdding.customscoreboard.config.categories.BackgroundConfig
 import me.owdding.customscoreboard.config.categories.LinesConfig
+import me.owdding.customscoreboard.feature.ModCompat
 import me.owdding.customscoreboard.feature.customscoreboard.ScoreboardLine.Companion.createColumn
 import me.owdding.customscoreboard.generated.ScoreboardEntry
 import me.owdding.customscoreboard.generated.ScoreboardEventEntry
@@ -29,6 +30,8 @@ import tech.thatgravyboat.skyblockapi.helpers.McClient
 
 @Module
 object CustomScoreboardRenderer {
+
+    private val isOverhaulLoaded = FabricLoader.getInstance().isModLoaded("scoreboard-overhaul")
 
     var lines: List<ScoreboardLine> = emptyList()
         private set
@@ -199,5 +202,6 @@ object CustomScoreboardRenderer {
     private fun isEnabled() = (LocationAPI.isOnSkyBlock || MainConfig.outsideSkyBlock) && MainConfig.enabled
     fun shouldUseCustomLines() = MainConfig.customLines && LocationAPI.isOnSkyBlock
     private fun hideHypixelScoreboard() = isEnabled() && MainConfig.hideHypixelScoreboard
-    fun renderScoreboardOverhaul() = FabricLoader.getInstance().isModLoaded("scoreboard-overhaul") && MainConfig.scoreboardOverhaul
+    fun renderScoreboardOverhaul() =
+        LocationAPI.isOnSkyBlock && MainConfig.enabled && isOverhaulLoaded && MainConfig.scoreboardOverhaul && ModCompat.isScoreboardOverhaulEnabled
 }

--- a/src/main/resources/customscoreboard.mixins.json
+++ b/src/main/resources/customscoreboard.mixins.json
@@ -4,6 +4,7 @@
     "package": "me.owdding.customscoreboard.mixins",
     "compatibilityLevel": "JAVA_21",
     "mixins": [
+        "compat.ScoreboardOverhaulConfigManagerMixin",
         "compat.ScoreboardOverhaulScoreboardAccessorMixin",
         "compat.SkyHanniCustomScoreboardMixin"
     ],

--- a/src/main/resources/customscoreboard.mixins.json
+++ b/src/main/resources/customscoreboard.mixins.json
@@ -4,7 +4,7 @@
     "package": "me.owdding.customscoreboard.mixins",
     "compatibilityLevel": "JAVA_21",
     "mixins": [
-        "compat.ScoreboardOverhaulConfigManagerMixin",
+      "compat.ScoreboardConfigMixin",
         "compat.ScoreboardOverhaulScoreboardAccessorMixin",
         "compat.SkyHanniCustomScoreboardMixin"
     ],

--- a/src/main/resources/customscoreboard.mixins.json
+++ b/src/main/resources/customscoreboard.mixins.json
@@ -4,7 +4,7 @@
     "package": "me.owdding.customscoreboard.mixins",
     "compatibilityLevel": "JAVA_21",
     "mixins": [
-      "compat.ScoreboardConfigMixin",
+        "compat.ScoreboardConfigMixin",
         "compat.ScoreboardOverhaulScoreboardAccessorMixin",
         "compat.SkyHanniCustomScoreboardMixin"
     ],


### PR DESCRIPTION
if one or the other (or both) were disabled, the other didnt show directly